### PR TITLE
0.17.x: Convert path PK strings to integers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.w3asel</groupId>
     <artifactId>inventree-sdk-java</artifactId>
     <packaging>jar</packaging>
-    <version>0.17.294.1-SNAPSHOT</version>
+    <version>0.17.294.2-SNAPSHOT</version>
 
     <name>InvenTree SDK (Java)</name>
     <description>A Java implementation of the OpenAPI spec published by InvenTree to allow interfacing with a server.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,11 @@
                             <token>(allOf|oneOf):(\n\s+- \$ref: '#/components/schemas/Status2a7Enum')(\n\s+- \$ref: '#/components/schemas/(Blank|Null)Enum')*</token>
                             <value>type: integer</value>
                         </replacement>
+                        <!-- convert string type PK path variables to int -->
+                        <replacement>
+                            <token>schema:(\n\s+)type: string\n\s+pattern: \^(\[0-9\]|\\d)+.*\$</token>
+                            <value>schema:$1type: integer</value>
+                        </replacement>
                     </replacements>
                 </configuration>
             </plugin>

--- a/src/test/java/com/w3asel/inventree/api/TestCompanyApi.java
+++ b/src/test/java/com/w3asel/inventree/api/TestCompanyApi.java
@@ -142,7 +142,7 @@ public class TestCompanyApi extends TestApi {
     @CsvSource({"1", "23"})
     public void companyRetrieve(int company) throws ApiException {
         JsonObject expected = InventreeDemoDataset.getObjects(Models.COMPANY, company).get(0);
-        Company actual = api.companyRetrieve(Integer.toString(company));
+        Company actual = api.companyRetrieve(company);
         assertCompanyEquals(expected, actual, true);
 
         // verify data not directly in demo dataset
@@ -346,7 +346,7 @@ public class TestCompanyApi extends TestApi {
     @ParameterizedTest
     @CsvSource({"1"})
     public void companyContactRetrieve(int contact) throws ApiException {
-        Contact actual = api.companyContactRetrieve(Integer.toString(contact));
+        Contact actual = api.companyContactRetrieve(contact);
         JsonObject expected =
                 InventreeDemoDataset.getObjects(Models.COMPANY_CONTACT, contact).get(0);
         assertContactEquals(expected, actual);
@@ -361,7 +361,7 @@ public class TestCompanyApi extends TestApi {
     @Test
     public void companyContactDelete_NotFound() {
         try {
-            api.companyContactDestroy2(Integer.toString(-1));
+            api.companyContactDestroy2(-1);
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -387,14 +387,14 @@ public class TestCompanyApi extends TestApi {
             Assertions.assertEquals(initialCount + 1, createdCount,
                     "Company count should have increased");
         } finally {
-            api.companyContactDestroy2(Integer.toString(actual.getPk()));
+            api.companyContactDestroy2(actual.getPk());
         }
 
         int deletedCount = api.companyContactList(1, company, null, null, null).getCount();
         Assertions.assertEquals(initialCount, deletedCount, "Contact count should have reset");
 
         try {
-            api.companyContactDestroy2(Integer.toString(actual.getPk()));
+            api.companyContactDestroy2(actual.getPk());
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -536,7 +536,7 @@ public class TestCompanyApi extends TestApi {
     @ParameterizedTest
     @CsvSource({"11"})
     public void companyPartRetrieve(int supplierPart) throws ApiException {
-        SupplierPart actual = api.companyPartRetrieve(Integer.toString(supplierPart));
+        SupplierPart actual = api.companyPartRetrieve(supplierPart);
         JsonObject expected =
                 InventreeDemoDataset.getObjects(Models.COMPANY_SUPPLIER_PART, supplierPart).get(0);
         assertSupplierPartEquals(expected, actual, true);
@@ -644,8 +644,7 @@ public class TestCompanyApi extends TestApi {
     @ParameterizedTest
     @CsvSource({"1"})
     public void companyPartManufacturerRetrieve(int manufacturerPart) throws ApiException {
-        ManufacturerPart actual =
-                api.companyPartManufacturerRetrieve(Integer.toString(manufacturerPart));
+        ManufacturerPart actual = api.companyPartManufacturerRetrieve(manufacturerPart);
         JsonObject expected = InventreeDemoDataset
                 .getObjects(Models.COMPANY_MANUFACTURER_PART, manufacturerPart).get(0);
         assertManufacturerPartEquals(expected, actual, true);
@@ -741,8 +740,7 @@ public class TestCompanyApi extends TestApi {
     @ParameterizedTest
     @CsvSource({"2,1"})
     public void companyPriceBreakRetrieve(int supplierPriceBreak, int company) throws ApiException {
-        SupplierPriceBreak actual =
-                api.companyPriceBreakRetrieve(Integer.toString(supplierPriceBreak));
+        SupplierPriceBreak actual = api.companyPriceBreakRetrieve(supplierPriceBreak);
         JsonObject expectedPriceBreak =
                 InventreeDemoDataset.getObjects(Models.COMPANY_SUPPLIER_PRICE_BREAK, 2).get(0);
         assertSupplierPriceBreakEquals(expectedPriceBreak, actual, true);

--- a/src/test/java/com/w3asel/inventree/api/TestUserApi.java
+++ b/src/test/java/com/w3asel/inventree/api/TestUserApi.java
@@ -46,8 +46,7 @@ public class TestUserApi extends TestApi {
 
     @Test
     public void userRetrieve_admin() throws ApiException {
-        ExtendedUser actual = api.userRetrieve("1"); // TODO why is this a string, regex only allows
-                                                     // digits?
+        ExtendedUser actual = api.userRetrieve(1);
         Assertions.assertNotNull(actual);
         Assertions.assertEquals(1, actual.getPk(), "Incorrect pk returned");
         Assertions.assertEquals("admin", actual.getUsername(), "Incorrect username returned");
@@ -62,8 +61,7 @@ public class TestUserApi extends TestApi {
 
     @Test
     public void userRetrieve_reader() throws ApiException {
-        ExtendedUser actual = api.userRetrieve("2"); // TODO why is this a string, regex only allows
-                                                     // digits?
+        ExtendedUser actual = api.userRetrieve(2);
         Assertions.assertNotNull(actual);
         Assertions.assertEquals(2, actual.getPk(), "Incorrect pk returned");
         Assertions.assertEquals("reader", actual.getUsername(), "Incorrect username returned");
@@ -91,7 +89,7 @@ public class TestUserApi extends TestApi {
 
     @Test
     public void userGroupRetrieve_readers() throws ApiException {
-        Group actual = api.userGroupRetrieve("1"); // TODO string
+        Group actual = api.userGroupRetrieve(1);
         Assertions.assertNotNull(actual);
     }
 


### PR DESCRIPTION
Several PK path parameters are defined in the schema as strings with a regex limiting them to be digits. This results in the relevant parameters in Java being type `String`. This PR changes them over to be type `Integer`, which is the expected type given that all the PKs are `Integer`s.