### PR TITLE
Add Code Coverage Tracking

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,10 +25,6 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.9
-
       - name: Generate Javadoc
         run: mvn javadoc:javadoc
 
@@ -44,10 +40,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-
-      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.9
 
       - name: Build with tests
         run: mvn verify -DskipTests
@@ -133,9 +125,6 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-        with:
-          maven-version: 3.9.9
 
       - name: Run tests
         run: mvn test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,3 +139,9 @@ jobs:
 
       - name: Run tests
         run: mvn test
+
+      # Report results
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <plugin-replacer.version>1.5.3</plugin-replacer.version>
         <plugin-openapi-generator.version>7.12.0</plugin-openapi-generator.version>
         <plugin-javadoc.version>3.11.2</plugin-javadoc.version>
+        <plugin-jacoco.version>0.8.12</plugin-jacoco.version>
         <plugin-source.version>3.3.1</plugin-source.version>
         <plugin-gpg.version>3.2.7</plugin-gpg.version>
         <plugin-central-publishing.version>0.7.0</plugin-central-publishing.version>
@@ -368,6 +369,25 @@
                         </tag>
                     </tags>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${plugin-jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Code coverage isn't a direct concern, considering all of the code is generated, but it may be useful to track when schema changes add endpoints that aren't tested yet. TBD how much value this actually brings.