### PR TITLE
Backport schema 330 fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -115,10 +115,10 @@ jobs:
         run: uv pip install --require-hashes -r InvenTree/src/backend/requirements-dev.txt
       - name: Run invoke install
         run: cd InvenTree && invoke install --uv
+      - name: Run invoke update
+        run: cd InvenTree && invoke update --uv --skip-backup --skip-static
       - name: Setup test environment
-        run: cd InvenTree && invoke dev.setup-test
-#      - name: Run invoke update
-#        run: cd InvenTree && invoke update --uv --skip-backup --skip-static
+        run: cd InvenTree && invoke dev.setup-test --ignore-update
       - name: Start InvenTree Server
         run: |
           cd InvenTree

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,19 @@
                             <token>schema:(\n\s+)type: string\n\s+pattern: \^(\[0-9\]|\\d)+.*\$</token>
                             <value>schema:$1type: integer</value>
                         </replacement>
+                        <!-- fix endpoints for bulk delete -->
+                        <replacement>
+                            <token>(attachment|background_task_failed|background_task_pending|barcode_history|bom|build_item|company_address|company_contact|company_part|company_part_manufacturer|company_part_manufacturer_parameter|error_report|importer_row|importer_session|news|notifications|order_po_line|stock|stock_test|user_tokens)_destroy(\n\s+)description: \|-(\n\s+Perform)</token>
+                            <value>$1_bulk_destroy$2requestBody:$2  content:$2    application/json:$2      schema:$2        \$ref: '#/components/schemas/BulkRequest'$2    application/x-www-form-urlencoded:$2      schema:$2        \$ref: '#/components/schemas/BulkRequest'$2    application/form-data:$2      schema:$2        \$ref: '#/components/schemas/BulkRequest'$2  required: true$2description: |-$3</value>
+                        </replacement>
+                        <replacement>
+                            <token>(?&lt;!user_tokens)_destroy_2</token>
+                            <value>_destroy</value>
+                        </replacement>
+                        <replacement>
+                            <token>output(\n\s+)Category:</token>
+                            <value>output$1BulkRequest:$1  type: object$1  description: Parameters for selecting items for bulk operations.$1  properties:$1    items:$1      type: array$1      items:$1        type: integer$1      title: A list of primary key values$1    filters:$1      type: object$1      additionalProperties: {}$1      title: A dictionary of filter values$1Category:</value>
+                        </replacement>
                     </replacements>
                 </configuration>
             </plugin>

--- a/src/test/java/com/w3asel/inventree/api/TestCompanyApi.java
+++ b/src/test/java/com/w3asel/inventree/api/TestCompanyApi.java
@@ -6,6 +6,7 @@ import com.w3asel.inventree.InventreeDemoDataset;
 import com.w3asel.inventree.InventreeDemoDataset.Models;
 import com.w3asel.inventree.invoker.ApiException;
 import com.w3asel.inventree.model.Address;
+import com.w3asel.inventree.model.BulkRequest;
 import com.w3asel.inventree.model.Company;
 import com.w3asel.inventree.model.CompanyBrief;
 import com.w3asel.inventree.model.Contact;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -240,7 +242,7 @@ public class TestCompanyApi extends TestApi {
     @Test
     public void companyAddressDelete_NotFound() {
         try {
-            api.companyAddressDestroy2(-1);
+            api.companyAddressDestroy(-1);
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -266,14 +268,14 @@ public class TestCompanyApi extends TestApi {
             Assertions.assertEquals(initialCount + 1, createdCount,
                     "Address count should have increased");
         } finally {
-            api.companyAddressDestroy2(actual.getPk());
+            api.companyAddressDestroy(actual.getPk());
         }
 
         int deletedCount = api.companyAddressList(1, company, null, null, null).getCount();
         Assertions.assertEquals(initialCount, deletedCount, "Address count should have reset");
 
         try {
-            api.companyAddressDestroy2(actual.getPk());
+            api.companyAddressDestroy(actual.getPk());
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -281,11 +283,15 @@ public class TestCompanyApi extends TestApi {
         }
     }
 
-    @Disabled
     @Test
-    public void companyAddressListDelete_NotFound() throws ApiException {
-        // TODO revisit when schema includes request content
-        api.companyAddressDestroy();
+    public void companyAddressBulkDelete_NotFound() {
+        try {
+            api.companyAddressBulkDestroy(new BulkRequest().items(List.of(-1, -2)));
+            Assertions.fail("Expected 400 Bad Request");
+        } catch (ApiException e) {
+            Assertions.assertTrue(e.getMessage().contains("No items found"),
+                    "Invalid key should not have been found.");
+        }
     }
 
     // TODO address update, address partial update
@@ -357,11 +363,10 @@ public class TestCompanyApi extends TestApi {
         }
     }
 
-
     @Test
     public void companyContactDelete_NotFound() {
         try {
-            api.companyContactDestroy2(-1);
+            api.companyContactDestroy(-1);
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -387,14 +392,14 @@ public class TestCompanyApi extends TestApi {
             Assertions.assertEquals(initialCount + 1, createdCount,
                     "Company count should have increased");
         } finally {
-            api.companyContactDestroy2(actual.getPk());
+            api.companyContactDestroy(actual.getPk());
         }
 
         int deletedCount = api.companyContactList(1, company, null, null, null).getCount();
         Assertions.assertEquals(initialCount, deletedCount, "Contact count should have reset");
 
         try {
-            api.companyContactDestroy2(actual.getPk());
+            api.companyContactDestroy(actual.getPk());
             Assertions.fail("Expected 404 Not Found");
         } catch (ApiException e) {
             Assertions.assertTrue(e.getMessage().contains("Not Found"),
@@ -402,11 +407,58 @@ public class TestCompanyApi extends TestApi {
         }
     }
 
-    @Disabled
     @Test
-    public void companyContactListDelete_NotFound() throws ApiException {
-        // TODO revisit when schema includes request content
-        api.companyContactDestroy();
+    public void companyContactBulkDestroy_NotFound() {
+        try {
+            api.companyContactBulkDestroy(new BulkRequest().items(List.of(-1, -2)));
+            Assertions.fail("Expected 400 Bad Request");
+        } catch (ApiException e) {
+            Assertions.assertTrue(e.getMessage().contains("No items found"),
+                    "Invalid key should not have been found.");
+        }
+    }
+
+    @Test
+    public void companyContactCreateListDelete() throws ApiException {
+        int company = 1;
+        int targetCount = 3;
+
+        int initialCount = api.companyContactList(1, company, null, null, null).getCount();
+
+        List<Integer> createdPks = new ArrayList<>();
+        try {
+            for (int i = 0; i < targetCount; i++) {
+                // set only required fields
+                Contact newContact = new Contact().company(company).name("Name");
+
+                Contact actual = api.companyContactCreate(newContact);
+                Assertions.assertNotNull(actual.getPk(), "Created contact should have PK");
+                createdPks.add(actual.getPk());
+            }
+
+            int createdCount = api.companyContactList(1, company, null, null, null).getCount();
+            Assertions.assertEquals(initialCount + targetCount, createdCount,
+                    "Company count should have increased");
+
+            try {
+                api.companyContactBulkDestroy(new BulkRequest().items(createdPks));
+            } catch (ApiException e) {
+                Assertions.assertTrue(
+                        e.getMessage().contains("HTTP 204 had non-zero Content-Length"),
+                        "Expected improper content (server sends wrong status code)");
+            }
+
+            int deletedCount = api.companyContactList(1, company, null, null, null).getCount();
+            Assertions.assertEquals(initialCount, deletedCount, "Contact count should have reset");
+        } finally {
+            for (int pk : createdPks) {
+                try {
+                    api.companyContactDestroy(pk);
+                } catch (ApiException e) {
+                    // should throw 404 exceptions on success
+                }
+            }
+        }
     }
 
     // TODO contact update, contact partial update


### PR DESCRIPTION
**Backport schema changes:**
- Deconflict operation id between single and bulk destroy operations
- Add request body definition for bulk destroy operations

**Known issues:**
- On success, bulk delete calls return HTTP 204 (No Content) with response content, which is invalid.